### PR TITLE
Replace `#!/bin/bash` with `#!/usr/bin/env bash`

### DIFF
--- a/RosBE-Unix/Base-i386/README
+++ b/RosBE-Unix/Base-i386/README
@@ -24,10 +24,7 @@ automatically checks for them:
 
   * GNU Bash
     The executable file and the package name are often called "bash".
-    All scripts are designed to work only under the Bash shell. Please also
-    make sure that the file "/bin/bash" exists. For example FreeBSD usually
-    installs Bash into another directory, so you have to create a symbolic
-    link "/bin/bash" to the executable file.
+    All scripts are designed to work only under the Bash shell.
 
   * GNU Bison
     The executable file and the package name are often called "bison".
@@ -63,19 +60,6 @@ automatically checks for them:
 
   * zlib
     The library file is generally called "libz.so".
-
-
-Preparing the installation
----------------------------
-  Under some operating systems, you need to perform additional steps before
-you can install the Build Environment. This section lists them.
-
-  * FreeBSD
-      - You have to create a symbolic link "/bin/bash", because FreeBSD
-        installs Bash to "/usr/local/bin/bash". Simply execute the following
-        command for doing this:
-
-        ln -s /usr/local/bin/bash /bin/bash
 
 
 Installation

--- a/RosBE-Unix/Base-i386/RosBE-Builder.sh
+++ b/RosBE-Unix/Base-i386/RosBE-Builder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ReactOS Build Environment for Unix-based Operating Systems - Builder Tool for the Base package
 # Copyright 2007-2011 Colin Finck <colin@reactos.org>

--- a/RosBE-Unix/Base-i386/scripts/RosBE.sh
+++ b/RosBE-Unix/Base-i386/scripts/RosBE.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for initializing RosBE
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/basedir.sh
+++ b/RosBE-Unix/Base-i386/scripts/basedir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for changing the current directory to $_ROSBE_ROSSOURCEDIR
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/build-multi.sh
+++ b/RosBE-Unix/Base-i386/scripts/build-multi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Detects the CPU cores in your system and builds ReactOS with this number of threads
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/build.sh
+++ b/RosBE-Unix/Base-i386/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Builds ReactOS with one thread
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/charch.sh
+++ b/RosBE-Unix/Base-i386/scripts/charch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Change the current target build tools to an architecture to build for
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/chdefdir.sh
+++ b/RosBE-Unix/Base-i386/scripts/chdefdir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Change the ReactOS source directory for the current session
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/clean.sh
+++ b/RosBE-Unix/Base-i386/scripts/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for cleaning the ReactOS source directory
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/createshortcut.sh
+++ b/RosBE-Unix/Base-i386/scripts/createshortcut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for creating shortcuts
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/help.sh
+++ b/RosBE-Unix/Base-i386/scripts/help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for displaying the help
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/pre-build/99-touch-reactos-dff-in.sh
+++ b/RosBE-Unix/Base-i386/scripts/pre-build/99-touch-reactos-dff-in.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Pre-build hook script to force CMake rehandle
 # reactos.dff (in then, handle optional components)

--- a/RosBE-Unix/Base-i386/scripts/scut.sh
+++ b/RosBE-Unix/Base-i386/scripts/scut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for launching scut and changing the current directory appropriately
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/Base-i386/scripts/version.sh
+++ b/RosBE-Unix/Base-i386/scripts/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Show the tool versions
 # Part of RosBE for Unix-based Operating Systems

--- a/RosBE-Unix/makepackage.sh
+++ b/RosBE-Unix/makepackage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ReactOS Build Environment for Unix-based Operating Systems - Packaging tool for the Base package
 # Copyright 2009 Colin Finck <colin@reactos.org>


### PR DESCRIPTION
This PR pulls the location of `bash` from the environment and makes any workarounds for systems like FreeBSD unnecessary that put the `bash` in a different directory.