### PR TITLE
[ROSBE][UNIX] Accept Yes/No answers with upper case letters

### DIFF
--- a/RosBE-Unix/Base-i386/RosBE-Builder.sh
+++ b/RosBE-Unix/Base-i386/RosBE-Builder.sh
@@ -179,7 +179,7 @@ if [ "$1" = "" ]; then
 					read -p "[no] " answer
 					echo
 
-					if [ "$answer" != "yes" ]; then
+					if [[ "$answer" != [yY][eE][sS] ]]; then
 						echo "Please enter another directory!"
 						installdir=""
 					fi

--- a/RosBE-Unix/Base-i386/scripts/rosbelibrary.sh
+++ b/RosBE-Unix/Base-i386/scripts/rosbelibrary.sh
@@ -38,7 +38,7 @@ check_root()
 		local answer
 		read -p "[no] " answer
 
-		if [ "$answer" = "yes" ]; then
+		if [[ "$answer" = [yY][eE][sS] ]]; then
 			echo
 		else
 			exit 1


### PR DESCRIPTION
As the commit message says, answering with upper case letters leads the script quitting. This patch should correct this behaviour.