### PR TITLE
 Add the option --disable-libstdcxx-verbose to gcc

### DIFF
--- a/RosBE-Unix/Base-i386/RosBE-Builder.sh
+++ b/RosBE-Unix/Base-i386/RosBE-Builder.sh
@@ -351,7 +351,7 @@ if rs_prepare_module "gcc"; then
 	export CFLAGS_FOR_TARGET="$rs_target_cflags"
 	export CXXFLAGS_FOR_TARGET="$rs_target_cflags"
 
-	rs_do_command ../gcc/configure --target="$rs_target" --prefix="$rs_archprefixdir" --with-sysroot="$rs_archprefixdir" --with-pkgversion="RosBE-Unix" --enable-languages=c,c++ --enable-fully-dynamic-string --enable-checking=release --enable-version-specific-runtime-libs --enable-plugins --disable-shared --disable-multilib --disable-nls --disable-werror --with-gnu-ld --with-gnu-as
+	rs_do_command ../gcc/configure --target="$rs_target" --prefix="$rs_archprefixdir" --with-sysroot="$rs_archprefixdir" --with-pkgversion="RosBE-Unix" --enable-languages=c,c++ --enable-fully-dynamic-string --enable-checking=release --enable-version-specific-runtime-libs --enable-plugins --disable-shared --disable-multilib --disable-nls --disable-libstdcxx-verbose --disable-werror --with-gnu-ld --with-gnu-as
 	# HUGE HACK!!!
 	# It "manually" disable doc generation for gcc
 	# This is required because our gcc is really old and

--- a/RosBE-Windows/Buildtoolchain/buildtoolchain.sh
+++ b/RosBE-Windows/Buildtoolchain/buildtoolchain.sh
@@ -248,7 +248,7 @@ if rs_prepare_module "gcc"; then
 	export C_INCLUDE_PATH="$rs_archprefixdir/$rs_target/include"
 	export LIBRARY_PATH="$rs_archprefixdir/$rs_target/lib"
 
-	rs_do_command ../gcc/configure --prefix="$rs_archprefixdir" --host="$rs_target" --build="$rs_target" --target="$rs_target" --with-gmp="$rs_supportprefixdir" --with-mpfr="$rs_supportprefixdir" --with-pkgversion="RosBE-Windows" --enable-languages=c,c++ --enable-checking=release --enable-version-specific-runtime-libs --disable-win32-registry --disable-shared --disable-nls --disable-werror
+	rs_do_command ../gcc/configure --prefix="$rs_archprefixdir" --host="$rs_target" --build="$rs_target" --target="$rs_target" --with-gmp="$rs_supportprefixdir" --with-mpfr="$rs_supportprefixdir" --with-pkgversion="RosBE-Windows" --enable-languages=c,c++ --enable-checking=release --enable-version-specific-runtime-libs --disable-win32-registry --disable-shared --disable-nls --disable-werror --disable-libstdcxx-verbose
 	rs_do_command $rs_makecmd profiledbootstrap
 	rs_do_command $rs_makecmd install
 	rs_clean_module "gcc"


### PR DESCRIPTION
This uses std::abort instead of __gnu_cxx::__verbose_terminate_handler, reducing binary output size for gcc.
(Our current gcc builds include a full c++ name demangler in every binary)