### PR TITLE
Installer should not hardcode the installdir path

### DIFF
--- a/RosBE-Windows/RosBE.nsi
+++ b/RosBE-Windows/RosBE.nsi
@@ -52,7 +52,12 @@ Function .onInit
     StrCmp $R0 0 +3
         MessageBox MB_OK|MB_ICONEXCLAMATION "The ${PRODUCT_NAME} v${PRODUCT_VERSION} installer is already running."
         Abort
-    StrCpy $INSTDIR "C:\RosBE"
+
+    ${If} $INSTDIR == "" ; InstallDirRegKey not valid?
+        StrCpy $0 $ProgramFiles 1
+        StrCpy $INSTDIR "$0:\RosBE"
+    ${EndIf}
+
     Call UninstallPrevious
     !insertmacro INSTALLOPTIONS_EXTRACT "RosSourceDir.ini"
 FunctionEnd

--- a/RosBE-Windows/RosBE.nsi
+++ b/RosBE-Windows/RosBE.nsi
@@ -54,7 +54,10 @@ Function .onInit
         Abort
 
     ${If} $INSTDIR == "" ; InstallDirRegKey not valid?
-        StrCpy $0 $ProgramFiles 1
+        StrCpy $0 $SysDir 1
+        ${If} $0 == "\"
+            StrCpy $0 'C'
+        ${EndIf}
         StrCpy $INSTDIR "$0:\RosBE"
     ${EndIf}
 


### PR DESCRIPTION
This changes $INSTDIR to respect InstallDirRegKey. If not present, the default is the drive of %ProgramFiles% instead of forcing c:\.