### PR TITLE
Fix: Replace pipes with shlex when Python version is 3.13 or higher.

### DIFF
--- a/RosBE-Unix/Base-i386/RosBE-Builder.sh
+++ b/RosBE-Unix/Base-i386/RosBE-Builder.sh
@@ -274,7 +274,9 @@ fi
 if rs_prepare_module "ninja"; then
 	# Python >= 3.13 removed the 'pipes' module, use 'shlex' as a drop-in replacement
 	if python -c "import sys; sys.exit(0 if sys.version_info >= (3,13) else 1)"; then
-		sed -i 's/^import pipes$/import shlex as pipes/' ../ninja/configure.py
+		if grep -q '^import pipes$' ../ninja/configure.py; then
+			sed -i 's/^import pipes$/import shlex as pipes/' ../ninja/configure.py
+		fi
 	fi
 	rs_do_command python ../ninja/configure.py --bootstrap
 	rs_do_command install ninja "$rs_prefixdir/bin"

--- a/RosBE-Unix/Base-i386/RosBE-Builder.sh
+++ b/RosBE-Unix/Base-i386/RosBE-Builder.sh
@@ -272,6 +272,10 @@ if rs_prepare_module "gcc"; then
 fi
 
 if rs_prepare_module "ninja"; then
+	# Python >= 3.13 removed the 'pipes' module, use 'shlex' as a drop-in replacement
+	if python -c "import sys; sys.exit(0 if sys.version_info >= (3,13) else 1)"; then
+		sed -i 's/^import pipes$/import shlex as pipes/' ../ninja/configure.py
+	fi
 	rs_do_command python ../ninja/configure.py --bootstrap
 	rs_do_command install ninja "$rs_prefixdir/bin"
 	rs_clean_module "ninja"


### PR DESCRIPTION
I encountered a Python error while running the build script for Ninja on Ubuntu 26.04. It turns out that Python 3.13+ has completely removed the pipes module, causing Ninja's configuration to fail.

To fix this, I modified the build script to use the shlex module instead of pipes when Python 3.13 or later is detected. I have tested this change, and it does not affect any existing functionality.

This is a temporary workaround. Since the Ninja version in the ReactOS toolchain isn't easily upgradable, this approach is more stable for now.