### PR TITLE
Add patch about replace shlex from pipes on Python 3.13+ to fix build error on new OS.

### DIFF
--- a/Patches/ninja-1.10.0-fix-python3.13-pipes-module.patch
+++ b/Patches/ninja-1.10.0-fix-python3.13-pipes-module.patch
@@ -1,11 +1,14 @@
 --- configure.py.orig	2026-03-25 16:12:10.647584559 +0800
-+++ configure.py	2026-03-25 16:12:10.651584755 +0800
-@@ -23,7 +23,7 @@
++++ configure.py	2026-03-25 16:39:00.122488627 +0800
+@@ -23,7 +23,10 @@
  
  from optparse import OptionParser
  import os
 -import pipes
-+import shlex as pipes
++try:
++    import pipes
++except ImportError:
++    import shlex as pipes
  import string
  import subprocess
  import sys

--- a/Patches/ninja-1.10.0-fix-python3.13-pipes-module.patch
+++ b/Patches/ninja-1.10.0-fix-python3.13-pipes-module.patch
@@ -1,0 +1,11 @@
+--- configure.py.orig	2026-03-25 16:12:10.647584559 +0800
++++ configure.py	2026-03-25 16:12:10.651584755 +0800
+@@ -23,7 +23,7 @@
+ 
+ from optparse import OptionParser
+ import os
+-import pipes
++import shlex as pipes
+ import string
+ import subprocess
+ import sys


### PR DESCRIPTION
I tried building RosBE on a modern Linux toolchain (Ubuntu 26.04), and found that the current RosBE's Ninja imports the `pipes` module, which is deprecated in Python 3.13+. This causes build issues on newer GNU/Linux, so I submitted a patch. I made a similar fix in a previous PR where I added `sed` to the bash script, but I felt that had the smell of a monkey patch and wasn't appropriate. I think using a patch is more suitable, so I opened a new PR.